### PR TITLE
Fix icon label in settings

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -49,7 +49,7 @@ export default class AudioQuickSwitcherPreferences extends ExtensionPreferences 
         shortcutRow.add_suffix(shortcutLabel);
 
         const editButton = new Gtk.Button({
-            icon_name: "edit-symbolic",
+            icon_name: "document-edit-symbolic",
             valign: Gtk.Align.CENTER,
             tooltip_text: _("Edit shortcut"),
         });


### PR DESCRIPTION
Use the correct icon label referencing the system-wide edit icon according to the preinstalled [Adwaita](https://github.com/GNOME/adwaita-icon-theme/tree/ff27ee6c5560c5c386c85a2d7d632ff0c14c3333/Adwaita/symbolic/actions) icon theme.